### PR TITLE
Use recommended bundle installation template

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,44 @@ In the examples provided below, you can see a controller and a handler that uses
 
 # Installation
 
-In your composer.json
-```json
-{
-    "require" : {
-        "hostnet/form-handler-bundle" : "master@dev"
-    }
-}
-```
->*Note*: Recommended is to use the current stable tag.
+## Step 1: Download the Bundle
 
-Then add the bundle in your AppKernel:
+Open a command console, enter your project directory and execute the
+following command to download the latest stable version of this bundle:
+
+```bash
+$ composer require hostnet/form-handler-bundle
+```
+
+This command requires you to have Composer installed globally, as explained
+in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
+of the Composer documentation.
+
+## Step 2: Enable the Bundle
+
+Then, enable the bundle by adding it to the list of registered bundles
+in the `app/AppKernel.php` file of your project:
+
 ```php
-    $bundles = [
+<?php
+// app/AppKernel.php
+
+// ...
+class AppKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        $bundles = array(
+            // ...
+
+            new Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle()
+        );
+
         // ...
-        new Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle()
-    ];
+    }
+
+    // ...
+}
 ```
 
 # Usage


### PR DESCRIPTION
Updated the instal part to follow the [recommended bundle install template](http://symfony.com/doc/current/bundles/best_practices#installation-instructions). This also gets rid of the not-so-nice `master@dev` version constraint.