### PR TITLE
Fix ParmConverter

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -4,7 +4,7 @@ services:
         arguments:
             - "@service_container"
         tags:
-            - { name: request.param_converter, priority: false, converter: form_information_converter }
+            - { name: request.param_converter, converter: form_information_converter }
 
     form_handler.provider.simple:
         class: Hostnet\Component\Form\Simple\SimpleFormProvider


### PR DESCRIPTION
sensiolabs/SensioFrameworkExtraBundle@2740c481c1dbaf94dcf23df2bf749eaadd49ecbd broke our ParamConverter because of the default === false value for the priority.