### PR TITLE
Fixed commented config file in test kernel

### DIFF
--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -21,11 +21,11 @@ class TestKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__.'/config/config_27.yml');
-//        if (self::VERSION_ID < 20800) {
-//        } else {
-//            $loader->load(__DIR__.'/config/config.yml');
-//        }
+        if (Kernel::VERSION_ID >= 30000) {
+            $loader->load(__DIR__.'/config/config.yml');
+        } else {
+            $loader->load(__DIR__.'/config/config_27.yml');
+        }
     }
 
     /**


### PR DESCRIPTION
Some left-overs that were missed in the test kernel. While it doesn't break anything as it's not executed, it should still only load the 2.7 container in when 2.7 is used.