### PR TITLE
Create additional bundle class according to Symfony best practices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/form":             "^2.7|^3.0",
         "symfony/framework-bundle": "^2.7|^3.0",
         "symfony/http-kernel":      "^2.7|^3.0",
-        "symfony/phpunit-bridge":   "^2.8|^3.0",
+        "symfony/phpunit-bridge":   "^2.7|^3.0",
         "symfony/translation":      "^2.7|^3.0",
         "symfony/validator":        "^2.7|^3.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,10 @@
         <server name="KERNEL_DIR" value="test/Functional/Fixtures"/>
     </php>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <testsuites>
         <testsuite name="hostnet/form-handler-bundle test suite">
             <directory>./test</directory>

--- a/src/FormHandlerBundle.php
+++ b/src/FormHandlerBundle.php
@@ -1,28 +1,28 @@
 <?php
 namespace Hostnet\Bundle\FormHandlerBundle;
-
-use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Yannick de Lange <ydelange@hostnet.nl>
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ *
+ * @deprecated The FormHandlerBundle is deprecated. Use Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle instead.
  */
-class FormHandlerBundle extends Bundle
+class FormHandlerBundle extends HostnetFormHandlerBundle
 {
     /**
-     * @see \Symfony\Component\HttpKernel\Bundle\Bundle::build()
+     * @param ContainerBuilder $container
      */
     public function build(ContainerBuilder $container)
     {
-        // load default services.yml
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Resources/config'));
-        $loader->load('services.yml');
-
+        @trigger_error(
+            sprintf(
+                'The %s class is deprecated. Use the %s class instead.',
+                FormHandlerBundle::class,
+                HostnetFormHandlerBundle::class
+            ),
+            E_USER_DEPRECATED
+        );
         parent::build($container);
-        $container->addCompilerPass(new FormParamConverterCompilerPass());
     }
 }

--- a/src/HostnetFormHandlerBundle.php
+++ b/src/HostnetFormHandlerBundle.php
@@ -1,0 +1,28 @@
+<?php
+namespace Hostnet\Bundle\FormHandlerBundle;
+
+use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Yannick de Lange <ydelange@hostnet.nl>
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ */
+class HostnetFormHandlerBundle extends Bundle
+{
+    /**
+     * @see \Symfony\Component\HttpKernel\Bundle\Bundle::build()
+     */
+    public function build(ContainerBuilder $container)
+    {
+        // load default services.yml
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Resources/config'));
+        $loader->load('services.yml');
+
+        parent::build($container);
+        $container->addCompilerPass(new FormParamConverterCompilerPass());
+    }
+}

--- a/test/FormHandlerBundleTest.php
+++ b/test/FormHandlerBundleTest.php
@@ -1,138 +1,30 @@
 <?php
 namespace Hostnet\Bundle\FormHandlerBundle;
-
-use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
- * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ * @author Piotr Rzeczkowski <piotr@rzeka.net>
  * @coversDefaultClass Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle
  */
 class FormHandlerBundleTest extends \PHPUnit_Framework_TestCase
 {
-    private $expected_resources = [
-        '/Resources/config/services.yml',
-        '/DependencyInjection/Compiler/FormParamConverterCompilerPass.php'
-    ];
-
-    private $expected_service_definitions = [
-        'form_handler.param_converter',
-        'form_handler.provider.simple',
-        'hostnet.form_handler.registry',
-        'hostnet.form_handler.factory',
-    ];
-
-    /**
-     * @covers ::build
-     */
-    public function testBuild()
+    public function testIsInstanceOfFormHandlerBundle()
     {
-        $container = new ContainerBuilder();
-
         $bundle = new FormHandlerBundle();
-        $bundle->build($container);
 
-        $passes = $container->getCompilerPassConfig()->getBeforeOptimizationPasses();
-        $this->assertTrue($passes[0] instanceof FormParamConverterCompilerPass);
+        $this->assertTrue($bundle instanceof HostnetFormHandlerBundle);
     }
 
     /**
-     * @covers ::build
-     * @dataProvider loadedResourcesProvider
+     * @group legacy
+     * @expectedDeprecation The %s is deprecated. Use %s instead.
      */
-    public function testLoadedResources(BundleInterface $bundle, array $expected_resources)
+    public function testIsDeprecated()
     {
         $container = new ContainerBuilder();
+        $bundle = new FormHandlerBundle();
+
         $bundle->build($container);
 
-        $resources = $container->getResources();
-
-        foreach ($resources as $resource) {
-            /* @var $resource \Symfony\Component\Config\Resource\ResourceInterface */
-            $resource_path            = $resource->getResource();
-            $expected_resources_count = count($expected_resources);
-
-            for ($i = 0; $i < $expected_resources_count; $i++) {
-                if (false !== strpos($resource_path, $expected_resources[$i])) {
-                    unset($expected_resources[$i]);
-                    break;
-                }
-            }
-
-            // reset indice
-            $expected_resources = array_values($expected_resources);
-
-            // found a resource we didn't expect
-            if (count($expected_resources) === $expected_resources_count) {
-                $this->fail('Test did not expect resource to be loaded: '. $resource_path);
-            }
-        }
-
-        $this->assertEmpty($expected_resources, 'Container resource(s) missing: ' . implode(',', $expected_resources));
-    }
-
-    /**
-     * @return array
-     */
-    public function loadedResourcesProvider()
-    {
-        return [
-            [new FormHandlerBundle(), $this->expected_resources]
-        ];
-    }
-
-    /**
-     * @covers ::build
-     * @dataProvider loadedServicesProvider
-     */
-    public function testLoadedServices(BundleInterface $bundle, array $expected_service_definitions)
-    {
-        $container = new ContainerBuilder();
-        $bundle->build($container);
-
-        $definitions = $container->getDefinitions();
-
-        foreach ($definitions as $id => $def) {
-            /* @var $def \Symfony\Component\DependencyInjection\Definition */
-            $class = $def->getClass();
-
-            $expected_service_definitions_count = count($expected_service_definitions);
-
-            for ($i = 0; $i < $expected_service_definitions_count; $i++) {
-                if ($id === $expected_service_definitions[$i]) {
-                    unset($expected_service_definitions[$i]);
-                    break;
-                }
-            }
-
-            // reset indice
-            $expected_service_definitions = array_values($expected_service_definitions);
-
-            // found a resource we didn't expect
-            if (count($expected_service_definitions) === $expected_service_definitions_count) {
-                $this->fail('Test did not expect service definition to be loaded: '. $id . ' with class ' . $class);
-            }
-
-            // test this later because fixing this failure can lead to the previous
-            if (!class_exists($class)) {
-                $this->fail(sprintf('Could not load class %s for definition %s', $class, $id));
-            }
-        }
-
-        $this->assertEmpty(
-            $expected_service_definitions,
-            'Service definition(s) missing: ' . implode(',', $expected_service_definitions)
-        );
-    }
-
-    /**
-     * @return array
-     */
-    public function loadedServicesProvider()
-    {
-        return [
-            [new FormHandlerBundle(), $this->expected_service_definitions]
-        ];
     }
 }

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -12,7 +12,7 @@ class TestKernel extends Kernel
     {
         return array(
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle(),
+            new Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle(),
         );
     }
 

--- a/test/HostnetFormHandlerBundleTest.php
+++ b/test/HostnetFormHandlerBundleTest.php
@@ -1,0 +1,138 @@
+<?php
+namespace Hostnet\Bundle\FormHandlerBundle;
+
+use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+/**
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ * @coversDefaultClass Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle
+ */
+class HostnetFormHandlerBundleTest extends \PHPUnit_Framework_TestCase
+{
+    private $expected_resources = [
+        '/Resources/config/services.yml',
+        '/DependencyInjection/Compiler/FormParamConverterCompilerPass.php'
+    ];
+
+    private $expected_service_definitions = [
+        'form_handler.param_converter',
+        'form_handler.provider.simple',
+        'hostnet.form_handler.registry',
+        'hostnet.form_handler.factory',
+    ];
+
+    /**
+     * @covers ::build
+     */
+    public function testBuild()
+    {
+        $container = new ContainerBuilder();
+
+        $bundle = new HostnetFormHandlerBundle();
+        $bundle->build($container);
+
+        $passes = $container->getCompilerPassConfig()->getBeforeOptimizationPasses();
+        $this->assertTrue($passes[0] instanceof FormParamConverterCompilerPass);
+    }
+
+    /**
+     * @covers ::build
+     * @dataProvider loadedResourcesProvider
+     */
+    public function testLoadedResources(BundleInterface $bundle, array $expected_resources)
+    {
+        $container = new ContainerBuilder();
+        $bundle->build($container);
+
+        $resources = $container->getResources();
+
+        foreach ($resources as $resource) {
+            /* @var $resource \Symfony\Component\Config\Resource\ResourceInterface */
+            $resource_path            = $resource->getResource();
+            $expected_resources_count = count($expected_resources);
+
+            for ($i = 0; $i < $expected_resources_count; $i++) {
+                if (false !== strpos($resource_path, $expected_resources[$i])) {
+                    unset($expected_resources[$i]);
+                    break;
+                }
+            }
+
+            // reset indice
+            $expected_resources = array_values($expected_resources);
+
+            // found a resource we didn't expect
+            if (count($expected_resources) === $expected_resources_count) {
+                $this->fail('Test did not expect resource to be loaded: '. $resource_path);
+            }
+        }
+
+        $this->assertEmpty($expected_resources, 'Container resource(s) missing: ' . implode(',', $expected_resources));
+    }
+
+    /**
+     * @return array
+     */
+    public function loadedResourcesProvider()
+    {
+        return [
+            [new HostnetFormHandlerBundle(), $this->expected_resources]
+        ];
+    }
+
+    /**
+     * @covers ::build
+     * @dataProvider loadedServicesProvider
+     */
+    public function testLoadedServices(BundleInterface $bundle, array $expected_service_definitions)
+    {
+        $container = new ContainerBuilder();
+        $bundle->build($container);
+
+        $definitions = $container->getDefinitions();
+
+        foreach ($definitions as $id => $def) {
+            /* @var $def \Symfony\Component\DependencyInjection\Definition */
+            $class = $def->getClass();
+
+            $expected_service_definitions_count = count($expected_service_definitions);
+
+            for ($i = 0; $i < $expected_service_definitions_count; $i++) {
+                if ($id === $expected_service_definitions[$i]) {
+                    unset($expected_service_definitions[$i]);
+                    break;
+                }
+            }
+
+            // reset indice
+            $expected_service_definitions = array_values($expected_service_definitions);
+
+            // found a resource we didn't expect
+            if (count($expected_service_definitions) === $expected_service_definitions_count) {
+                $this->fail('Test did not expect service definition to be loaded: '. $id . ' with class ' . $class);
+            }
+
+            // test this later because fixing this failure can lead to the previous
+            if (!class_exists($class)) {
+                $this->fail(sprintf('Could not load class %s for definition %s', $class, $id));
+            }
+        }
+
+        $this->assertEmpty(
+            $expected_service_definitions,
+            'Service definition(s) missing: ' . implode(',', $expected_service_definitions)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function loadedServicesProvider()
+    {
+        return [
+            [new HostnetFormHandlerBundle(), $this->expected_service_definitions]
+        ];
+    }
+}


### PR DESCRIPTION
Symfony Flex registers bundle automatically but instead of using
`FormHandlerBundle` is goes with `HostnetFormHandlerBundle`