### PR TITLE
Added 3.4 to the allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ matrix:
     - php: 7.0
       env: COMPOSER_FLAGS=""
     - php: 7.1
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="3.4.x-dev"
+    - php: 7.1
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="dev-master"
   allow_failures:
+    - php: 7.1
+      env: COMPOSER_FLAGS="" SYMFONY_VERSION="3.4.x-dev"
     - php: 7.1
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="dev-master"
 


### PR DESCRIPTION
The master will definitely fail due to dependency conflicts for 4.0. The 3.4 branch however, should not fail, but could due to development.