### PR TITLE
Create additional bundle class according to Symfony best practices

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/form":             "^2.7|^3.0",
         "symfony/framework-bundle": "^2.7|^3.0",
         "symfony/http-kernel":      "^2.7|^3.0",
-        "symfony/phpunit-bridge":   "^2.7|^3.0",
+        "symfony/phpunit-bridge":   "^2.8|^3.0",
         "symfony/translation":      "^2.7|^3.0",
         "symfony/validator":        "^2.7|^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/form":             "^2.7|^3.0",
         "symfony/framework-bundle": "^2.7|^3.0",
         "symfony/http-kernel":      "^2.7|^3.0",
-        "symfony/phpunit-bridge":   "^2.8|^3.0",
+        "symfony/phpunit-bridge":   "^2.7|^3.0",
         "symfony/translation":      "^2.7|^3.0",
         "symfony/validator":        "^2.7|^3.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,10 @@
         <server name="KERNEL_DIR" value="test/Functional/Fixtures"/>
     </php>
 
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+
     <testsuites>
         <testsuite name="hostnet/form-handler-bundle test suite">
             <directory>./test</directory>

--- a/src/FormHandlerBundle.php
+++ b/src/FormHandlerBundle.php
@@ -3,29 +3,29 @@
  * @copyright 2014-2017 Hostnet B.V.
  */
 namespace Hostnet\Bundle\FormHandlerBundle;
-
-use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * @author Yannick de Lange <ydelange@hostnet.nl>
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ *
+ * @deprecated The FormHandlerBundle is deprecated. Use Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle instead.
  */
-class FormHandlerBundle extends Bundle
+class FormHandlerBundle extends HostnetFormHandlerBundle
 {
     /**
-     * @see \Symfony\Component\HttpKernel\Bundle\Bundle::build()
+     * @param ContainerBuilder $container
      */
     public function build(ContainerBuilder $container)
     {
-        // load default services.yml
-        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Resources/config'));
-        $loader->load('services.yml');
-
+        @trigger_error(
+            sprintf(
+                'The %s class is deprecated. Use the %s class instead.',
+                FormHandlerBundle::class,
+                HostnetFormHandlerBundle::class
+            ),
+            E_USER_DEPRECATED
+        );
         parent::build($container);
-        $container->addCompilerPass(new FormParamConverterCompilerPass());
     }
 }

--- a/src/HostnetFormHandlerBundle.php
+++ b/src/HostnetFormHandlerBundle.php
@@ -1,0 +1,28 @@
+<?php
+namespace Hostnet\Bundle\FormHandlerBundle;
+
+use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @author Yannick de Lange <ydelange@hostnet.nl>
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ */
+class HostnetFormHandlerBundle extends Bundle
+{
+    /**
+     * @see \Symfony\Component\HttpKernel\Bundle\Bundle::build()
+     */
+    public function build(ContainerBuilder $container)
+    {
+        // load default services.yml
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/Resources/config'));
+        $loader->load('services.yml');
+
+        parent::build($container);
+        $container->addCompilerPass(new FormParamConverterCompilerPass());
+    }
+}

--- a/test/FormHandlerBundleTest.php
+++ b/test/FormHandlerBundleTest.php
@@ -1,36 +1,30 @@
 <?php
-/**
- * @copyright 2017 Hostnet B.V.
- */
 namespace Hostnet\Bundle\FormHandlerBundle;
-
-use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @author Iltar van der Berg <ivanderberg@hostnet.nl>
- * @covers \Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle
+ * @author Piotr Rzeczkowski <piotr@rzeka.net>
+ * @coversDefaultClass Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle
  */
 class FormHandlerBundleTest extends \PHPUnit_Framework_TestCase
 {
-    public function testBuild()
+    public function testIsInstanceOfFormHandlerBundle()
+    {
+        $bundle = new FormHandlerBundle();
+
+        $this->assertTrue($bundle instanceof HostnetFormHandlerBundle);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The %s is deprecated. Use %s instead.
+     */
+    public function testIsDeprecated()
     {
         $container = new ContainerBuilder();
-
         $bundle = new FormHandlerBundle();
+
         $bundle->build($container);
 
-        $found = false;
-
-        foreach ($container->getCompilerPassConfig()->getBeforeOptimizationPasses() as $pass) {
-            if (!$pass instanceof FormParamConverterCompilerPass) {
-                continue;
-            }
-
-            $found = true;
-            break;
-        }
-
-        self::assertTrue($found, 'Expected to find a compiler pass instance of the FormParamConverterCompilerPass.');
     }
 }

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -12,7 +12,7 @@ class TestKernel extends Kernel
     {
         return array(
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle(),
+            new Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle(),
         );
     }
 

--- a/test/HostnetFormHandlerBundleTest.php
+++ b/test/HostnetFormHandlerBundleTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Hostnet\Bundle\FormHandlerBundle;
+
+use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ * @coversDefaultClass Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle
+ */
+class HostnetFormHandlerBundleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBuild()
+    {
+        $container = new ContainerBuilder();
+
+        $bundle = new HostnetFormHandlerBundle();
+        $bundle->build($container);
+
+        $found = false;
+
+        foreach ($container->getCompilerPassConfig()->getBeforeOptimizationPasses() as $pass) {
+            if (!$pass instanceof FormParamConverterCompilerPass) {
+                continue;
+            }
+
+            $found = true;
+            break;
+        }
+
+        self::assertTrue($found, 'Expected to find a compiler pass instance of the FormParamConverterCompilerPass.');
+    }
+}


### PR DESCRIPTION
Rebased with the master after the travis config changed and broken tests with 3.3 got fixed. Due to symfony/phpunit-bridge, I've set it back to 2.8. This PR is a continuation of #30. 