### PR TITLE
Move symfony extra bundle into the suggest section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - php: 5.6
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="2.8.*"
     - php: 7.0
-      env: COMPOSER_FLAGS=""
+      env: COMPOSER_FLAGS="" EXTRA_BUNDLE=1
     - php: 7.1
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="3.4.x-dev"
     - php: 7.1
@@ -31,7 +31,9 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="dev-master"
 
-before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
+before_install: 
+    - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
+    - if [[ "$EXTRA_BUNDLE" != "" ]]; then composer remove "sensio/framework-extra-bundle" --dev; fi;
 
 install: composer update $COMPOSER_FLAGS --prefer-dist
 

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,14 @@
     "require": {
         "php":                            "^5.6|^7.0",
         "hostnet/form-handler-component": "^1.4.0",
-        "sensio/framework-extra-bundle":  "3.*",
         "symfony/expression-language":    "^2.7|^3.0",
         "symfony/http-foundation":        "^2.7|^3.0"
     },
     "require-dev": {
+        "doctrine/annotations":     "^1.5",
         "hostnet/phpcs-tool":       "^4.1.0",
         "phpunit/phpunit":          "^4.7|^5.0",
+        "sensio/framework-extra-bundle":  "3.*",
         "symfony/finder":           "^2.7|^3.0",
         "symfony/form":             "^2.7|^3.0",
         "symfony/framework-bundle": "^2.7|^3.0",
@@ -30,6 +31,9 @@
         "symfony/phpunit-bridge":   "^2.8|^3.0",
         "symfony/translation":      "^2.7|^3.0",
         "symfony/validator":        "^2.7|^3.0"
+    },
+    "suggest": {
+        "sensio/framework-extra-bundle":  "To utilize form param converter."
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,20 +20,20 @@
         "symfony/http-foundation":        "^2.7|^3.0"
     },
     "require-dev": {
-        "doctrine/annotations":     "^1.5",
-        "hostnet/phpcs-tool":       "^4.1.0",
-        "phpunit/phpunit":          "^4.7|^5.0",
-        "sensio/framework-extra-bundle":  "3.*",
-        "symfony/finder":           "^2.7|^3.0",
-        "symfony/form":             "^2.7|^3.0",
-        "symfony/framework-bundle": "^2.7|^3.0",
-        "symfony/http-kernel":      "^2.7|^3.0",
-        "symfony/phpunit-bridge":   "^2.8|^3.0",
-        "symfony/translation":      "^2.7|^3.0",
-        "symfony/validator":        "^2.7|^3.0"
+        "doctrine/annotations":          "^1.0",
+        "hostnet/phpcs-tool":            "^4.1.0",
+        "phpunit/phpunit":               "^4.7|^5.0",
+        "sensio/framework-extra-bundle": "3.*",
+        "symfony/finder":                "^2.7|^3.0",
+        "symfony/form":                  "^2.7|^3.0",
+        "symfony/framework-bundle":      "^2.7|^3.0",
+        "symfony/http-kernel":           "^2.7|^3.0",
+        "symfony/phpunit-bridge":        "^2.8|^3.0",
+        "symfony/translation":           "^2.7|^3.0",
+        "symfony/validator":             "^2.7|^3.0"
     },
     "suggest": {
-        "sensio/framework-extra-bundle":  "To utilize form param converter."
+        "sensio/framework-extra-bundle": "To utilize form param converter."
     },
     "autoload": {
         "psr-4": {

--- a/src/HostnetFormHandlerBundle.php
+++ b/src/HostnetFormHandlerBundle.php
@@ -1,7 +1,7 @@
 <?php
 namespace Hostnet\Bundle\FormHandlerBundle;
 
-use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
+use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormHandlerRegistryCompilerPass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -23,6 +23,6 @@ class HostnetFormHandlerBundle extends Bundle
         $loader->load('services.yml');
 
         parent::build($container);
-        $container->addCompilerPass(new FormParamConverterCompilerPass());
+        $container->addCompilerPass(new FormHandlerRegistryCompilerPass());
     }
 }

--- a/test/DependencyInjection/FormHandlerRegistryCompilerPassTest.php
+++ b/test/DependencyInjection/FormHandlerRegistryCompilerPassTest.php
@@ -9,28 +9,17 @@ use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
- * @covers \Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass
+ * @covers \Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormHandlerRegistryCompilerPass
  */
-class FormParamConverterCompilerPassTest extends \PHPUnit_Framework_TestCase
+class FormHandlerRegistryCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
-    public function testProcessNoDef()
+    protected function setUp()
     {
-        $container = $this
-            ->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $container
-            ->expects($this->once())
-            ->method('hasDefinition')
-            ->will($this->returnValue(false));
-
-        $container
-            ->expects($this->never())
-            ->method('getDefinition');
-
-        $pass = new FormParamConverterCompilerPass();
-        $pass->process($container);
+        if (!interface_exists('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')) {
+            $this->markTestSkipped(
+              'Sensio Extra bundle is not installed.'
+            );
+        }
     }
 
     /**
@@ -46,7 +35,7 @@ class FormParamConverterCompilerPassTest extends \PHPUnit_Framework_TestCase
             $container->register($id)->addTag($tag, ['tests']);
         }
 
-        $pass = new FormParamConverterCompilerPass();
+        $pass = new FormHandlerRegistryCompilerPass();
         $pass->process($container);
     }
 

--- a/test/HostnetFormHandlerBundleTest.php
+++ b/test/HostnetFormHandlerBundleTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Hostnet\Bundle\FormHandlerBundle;
 
-use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormParamConverterCompilerPass;
+use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormHandlerRegistryCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -20,7 +20,7 @@ class HostnetFormHandlerBundleTest extends \PHPUnit_Framework_TestCase
         $found = false;
 
         foreach ($container->getCompilerPassConfig()->getBeforeOptimizationPasses() as $pass) {
-            if (!$pass instanceof FormParamConverterCompilerPass) {
+            if (!$pass instanceof FormHandlerRegistryCompilerPass) {
                 continue;
             }
 

--- a/test/ParamConverter/FormParamConverterTest.php
+++ b/test/ParamConverter/FormParamConverterTest.php
@@ -18,6 +18,13 @@ class FormParamConverterTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        if (!interface_exists('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')) {
+            $this->markTestSkipped(
+              'Sensio Extra bundle is not installed.'
+            );
+            return;
+        }
+
         $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
         $this->request   = new Request();
     }


### PR DESCRIPTION
Not everybody wants to use extra bundle. IMO it should be inside of suggest section and if one wants to use it then it should require it as explicit dependency.