### PR TITLE
Add service aliases

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -22,3 +22,10 @@ services:
         arguments:
             - "@form.factory"
             - "@hostnet.form_handler.registry"
+
+    Hostnet\Bundle\FormHandlerBundle\ParamConverter\FormParamConverter: '@form_handler.param_converter'
+    Hostnet\Bundle\FormHandlerBundle\Registry\LegacyHandlerRegistry: '@hostnet.form_handler.registry'
+    Hostnet\Component\Form\FormProviderInterface: '@form_handler.provider.simple'
+    Hostnet\Component\Form\Simple\SimpleFormProvider: '@form_handler.provider.simple'
+    Hostnet\Component\FormHandler\HandlerRegistryInterface: '@hostnet.form_handler.registry'
+    Hostnet\Component\FormHandler\HandlerFactory: '@hostnet.form_handler.factory'

--- a/test/DependencyInjection/FormHandlerRegistryCompilerPassTest.php
+++ b/test/DependencyInjection/FormHandlerRegistryCompilerPassTest.php
@@ -4,6 +4,7 @@
  */
 namespace Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler;
 
+use Hostnet\Bundle\FormHandlerBundle\ParamConverter\FormParamConverter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -25,10 +26,10 @@ class FormHandlerRegistryCompilerPassTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider processDataProvider
      */
-    public function testProcess($tagged_services)
+    public function testProcess($service_name, $tagged_services)
     {
         $container = new ContainerBuilder();
-        $container->setDefinition('form_handler.param_converter', new Definition());
+        $container->setDefinition($service_name, new Definition());
         $container->setDefinition('hostnet.form_handler.registry', new Definition(null, [null, null]));
 
         foreach ($tagged_services as $id => $tag) {
@@ -42,8 +43,10 @@ class FormHandlerRegistryCompilerPassTest extends \PHPUnit_Framework_TestCase
     public function processDataProvider()
     {
         return [
-            [[]],
-            [['test.service' => 'form.handler', 'test.phpunit' => 'form.handler']]
+            ['form_handler.param_converter', []],
+            [FormParamConverter::class, []],
+            ['form_handler.param_converter', ['test.service' => 'form.handler', 'test.phpunit' => 'form.handler']],
+            [FormParamConverter::class, ['test.service' => 'form.handler', 'test.phpunit' => 'form.handler']],
         ];
     }
 }

--- a/test/Functional/ControllerTest.php
+++ b/test/Functional/ControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+
+namespace Hostnet\Bundle\FormHandlerBundle\Functional;
+
+use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestController;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Controller test.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class ControllerTest extends KernelTestCase
+{
+    protected function setUp()
+    {
+        static::bootKernel();
+    }
+
+    public function test()
+    {
+        if (Kernel::VERSION_ID < 30300) {
+            self::markTestSkipped(sprintf('Symfony version %s not supported by test', Kernel::VERSION));
+        }
+        if (!interface_exists('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')) {
+            $this->markTestSkipped(
+                'Sensio Extra bundle is not installed.'
+            );
+        }
+
+        $container = self::$kernel->getContainer();
+        $container->get(TestController::class);
+
+        // We only care that the controller instantiates correctly
+        $this->addToAssertionCount(1);
+    }
+}

--- a/test/Functional/Fixtures/TestController.php
+++ b/test/Functional/Fixtures/TestController.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+
+namespace Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures;
+
+use Hostnet\Bundle\FormHandlerBundle\ParamConverter\FormParamConverter;
+use Hostnet\Bundle\FormHandlerBundle\Registry\LegacyHandlerRegistry;
+use Hostnet\Component\Form\Simple\SimpleFormProvider;
+use Hostnet\Component\FormHandler\HandlerFactory;
+
+/**
+ * Controller testing fixture.
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class TestController
+{
+    /** @var FormParamConverter */
+    private $converter;
+    /** @var SimpleFormProvider */
+    private $provider;
+    /** @var LegacyHandlerRegistry */
+    private $registry;
+    /** @var HandlerFactory */
+    private $handler;
+
+    public function __construct(
+        FormParamConverter $converter,
+        SimpleFormProvider $provider,
+        LegacyHandlerRegistry $registry,
+        HandlerFactory $handler
+    ) {
+        $this->converter = $converter;
+        $this->provider = $provider;
+        $this->registry = $registry;
+        $this->handler = $handler;
+    }
+}

--- a/test/Functional/Fixtures/config/config_33.yml
+++ b/test/Functional/Fixtures/config/config_33.yml
@@ -33,6 +33,9 @@ services:
         alias: 'Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyNamedFormHandler'
         public: true
 
+    Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestController:
+        tags: ['controller.service_arguments']
+
 framework:
     test: true
 

--- a/test/Functional/HandlerTest.php
+++ b/test/Functional/HandlerTest.php
@@ -7,13 +7,7 @@ namespace Hostnet\Bundle\FormHandlerBundle\Functional;
 
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\FullFormHandler;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\FullFormHandler27;
-use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\SimpleFormHandler;
-use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\SimpleNotTaggedFormHandler;
-use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyFormHandler;
-use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyFormVariableOptionsHandler;
-use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyNamedFormHandler;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestData;
-use Hostnet\Component\FormHandler\HandlerTypeAdapter;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
This enables the services to be DIed on type hint:

`public function myAction(Request $request, HandlerFactory $handlerFactory): Response`

Fixes #48