### PR TITLE
Allow a specific config per test

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
 
     <php>
         <server name="KERNEL_DIR" value="test/Functional/Fixtures"/>
-        <server name="KERNEL_CLASS" value="TestKernel"/>
+        <server name="KERNEL_CLASS" value="Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures"/>
     </php>
 
     <listeners>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,11 +4,6 @@
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.0/phpunit.xsd"
     colors="true" bootstrap="vendor/autoload.php">
 
-    <php>
-        <server name="KERNEL_DIR" value="test/Functional/Fixtures"/>
-        <server name="KERNEL_CLASS" value="Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures"/>
-    </php>
-
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>

--- a/test/Functional/ControllerTest.php
+++ b/test/Functional/ControllerTest.php
@@ -21,15 +21,7 @@ class ControllerTest extends KernelTestCase
      */
     protected function setUp()
     {
-        $file = 'config_27.yml';
-
-        if (Kernel::VERSION_ID >= 30300) {
-            $file = 'config_33.yml';
-        } elseif (Kernel::VERSION_ID >= 30000) {
-            $file = 'config_32.yml';
-        }
-
-        static::bootKernel(['config_file' => $file]);
+        static::bootKernel(['config_file' => TestKernel::getLegacyConfigFilename()]);
     }
 
     protected static function createKernel(array $options = array())

--- a/test/Functional/ControllerTest.php
+++ b/test/Functional/ControllerTest.php
@@ -2,10 +2,10 @@
 /**
  * @copyright 2017 Hostnet B.V.
  */
-
 namespace Hostnet\Bundle\FormHandlerBundle\Functional;
 
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestController;
+use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -16,9 +16,25 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class ControllerTest extends KernelTestCase
 {
+    /**
+     * BC for current tests, new tests should get their own config.
+     */
     protected function setUp()
     {
-        static::bootKernel();
+        $file = 'config_27.yml';
+
+        if (Kernel::VERSION_ID >= 30300) {
+            $file = 'config_33.yml';
+        } elseif (Kernel::VERSION_ID >= 30000) {
+            $file = 'config_32.yml';
+        }
+
+        static::bootKernel(['config_file' => $file]);
+    }
+
+    protected static function createKernel(array $options = array())
+    {
+        return new TestKernel($options);
     }
 
     public function test()

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -22,6 +22,19 @@ final class TestKernel extends Kernel
         );
     }
 
+    public static function getLegacyConfigFilename()
+    {
+        if (Kernel::VERSION_ID >= 30300) {
+            return 'config_33.yml';
+        }
+
+        if (Kernel::VERSION_ID >= 30000) {
+            return 'config_32.yml';
+        }
+
+        return 'config_27.yml';
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -1,19 +1,35 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+namespace Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
-class TestKernel extends Kernel
+final class TestKernel extends Kernel
 {
+    private $config_file;
+
+    public function __construct(array $options)
+    {
+        $this->config_file = isset($options['config_file']) ? $options['config_file'] : 'config.yml';
+
+        parent::__construct(
+            isset($options['environment']) ? $options['environment'] : 'test',
+            isset($options['debug']) ? $options['debug'] : true
+        );
+    }
+
     /**
      * {@inheritdoc}
      */
     public function registerBundles()
     {
         return array(
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle(),
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle(),
         );
     }
 
@@ -22,13 +38,7 @@ class TestKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        if (Kernel::VERSION_ID >= 30300) {
-            $loader->load(__DIR__.'/config/config_33.yml');
-        } elseif (Kernel::VERSION_ID >= 30000) {
-            $loader->load(__DIR__.'/config/config_32.yml');
-        } else {
-            $loader->load(__DIR__.'/config/config_27.yml');
-        }
+        $loader->load(__DIR__."/config/{$this->config_file}");
     }
 
     protected function prepareContainer(ContainerBuilder $container)

--- a/test/Functional/Fixtures/TestType27.php
+++ b/test/Functional/Fixtures/TestType27.php
@@ -5,7 +5,6 @@
 namespace Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/test/Functional/HandlerTest.php
+++ b/test/Functional/HandlerTest.php
@@ -2,12 +2,12 @@
 /**
  * @copyright 2017 Hostnet B.V.
  */
-
 namespace Hostnet\Bundle\FormHandlerBundle\Functional;
 
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\FullFormHandler;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\FullFormHandler27;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestData;
+use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,9 +15,25 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class HandlerTest extends KernelTestCase
 {
+    /**
+     * BC for current tests, new tests should get their own config.
+     */
     protected function setUp()
     {
-        static::bootKernel();
+        $file = 'config_27.yml';
+
+        if (Kernel::VERSION_ID >= 30300) {
+            $file = 'config_33.yml';
+        } elseif (Kernel::VERSION_ID >= 30000) {
+            $file = 'config_32.yml';
+        }
+
+        static::bootKernel(['config_file' => $file]);
+    }
+
+    protected static function createKernel(array $options = array())
+    {
+        return new TestKernel($options);
     }
 
     public function testValid()

--- a/test/Functional/HandlerTest.php
+++ b/test/Functional/HandlerTest.php
@@ -20,15 +20,7 @@ class HandlerTest extends KernelTestCase
      */
     protected function setUp()
     {
-        $file = 'config_27.yml';
-
-        if (Kernel::VERSION_ID >= 30300) {
-            $file = 'config_33.yml';
-        } elseif (Kernel::VERSION_ID >= 30000) {
-            $file = 'config_32.yml';
-        }
-
-        static::bootKernel(['config_file' => $file]);
+        static::bootKernel(['config_file' => TestKernel::getLegacyConfigFilename()]);
     }
 
     protected static function createKernel(array $options = array())

--- a/test/Functional/RegistryTest.php
+++ b/test/Functional/RegistryTest.php
@@ -22,15 +22,7 @@ class RegistryTest extends KernelTestCase
      */
     protected function setUp()
     {
-        $file = 'config_27.yml';
-
-        if (Kernel::VERSION_ID >= 30300) {
-            $file = 'config_33.yml';
-        } elseif (Kernel::VERSION_ID >= 30000) {
-            $file = 'config_32.yml';
-        }
-
-        static::bootKernel(['config_file' => $file]);
+        static::bootKernel(['config_file' => TestKernel::getLegacyConfigFilename()]);
     }
 
     protected static function createKernel(array $options = array())

--- a/test/Functional/RegistryTest.php
+++ b/test/Functional/RegistryTest.php
@@ -2,7 +2,6 @@
 /**
  * @copyright 2017 Hostnet B.V.
  */
-
 namespace Hostnet\Bundle\FormHandlerBundle\Functional;
 
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\FullFormHandler;
@@ -11,14 +10,32 @@ use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\SimpleNotTa
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyFormHandler;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyFormVariableOptionsHandler;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyNamedFormHandler;
+use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestKernel;
 use Hostnet\Component\FormHandler\HandlerTypeAdapter;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\Kernel;
 
 class RegistryTest extends KernelTestCase
 {
+    /**
+     * BC for current tests, new tests should get their own config.
+     */
     protected function setUp()
     {
-        static::bootKernel();
+        $file = 'config_27.yml';
+
+        if (Kernel::VERSION_ID >= 30300) {
+            $file = 'config_33.yml';
+        } elseif (Kernel::VERSION_ID >= 30000) {
+            $file = 'config_32.yml';
+        }
+
+        static::bootKernel(['config_file' => $file]);
+    }
+
+    protected static function createKernel(array $options = array())
+    {
+        return new TestKernel($options);
     }
 
     public function test()


### PR DESCRIPTION
This change will allow new tests to use a specific config file. I've kept the current tests with the same logic to ensure we don't end up missing regressions.