### PR TITLE
Optimized the parameter converter arguments

### DIFF
--- a/src/DependencyInjection/Compiler/FormHandlerRegistryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FormHandlerRegistryCompilerPass.php
@@ -35,7 +35,7 @@ class FormHandlerRegistryCompilerPass implements CompilerPassInterface
             $class      = $container->getDefinition($id)->setPublic(true)->getClass();
             $handlers[] = [$id, $class];
 
-            if ($register_with_param_converter && is_a($class, FormHandlerInterface::class, true)) {
+            if ($register_with_param_converter && is_subclass_of($class, FormHandlerInterface::class)) {
                 $legacy_handlers[$id] = $class;
             }
         }

--- a/src/DependencyInjection/Compiler/FormHandlerRegistryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/FormHandlerRegistryCompilerPass.php
@@ -4,6 +4,7 @@
  */
 namespace Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler;
 
+use Hostnet\Component\Form\FormHandlerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -23,23 +24,27 @@ class FormHandlerRegistryCompilerPass implements CompilerPassInterface
         if (interface_exists('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')
             && $container->hasDefinition('form_handler.param_converter')
         ) {
-            $definition                    = $container->getDefinition('form_handler.param_converter');
             $register_with_param_converter = true;
         }
 
         $tagged_services = array_keys($container->findTaggedServiceIds('form.handler'));
         $handlers        = [];
+        $legacy_handlers = [];
 
         foreach ($tagged_services as $id) {
             $class      = $container->getDefinition($id)->setPublic(true)->getClass();
             $handlers[] = [$id, $class];
 
-            if ($register_with_param_converter) {
-                $definition->addMethodCall('addFormClass', [$id, $class]);
+            if ($register_with_param_converter && is_a($class, FormHandlerInterface::class, true)) {
+                $legacy_handlers[$id] = $class;
             }
         }
 
         // Add handlers to registry
         $container->getDefinition('hostnet.form_handler.registry')->replaceArgument(1, $handlers);
+
+        if (count($legacy_handlers) > 0) {
+            $container->getDefinition('form_handler.param_converter')->replaceArgument(1, $legacy_handlers);
+        }
     }
 }

--- a/src/ParamConverter/FormParamConverter.php
+++ b/src/ParamConverter/FormParamConverter.php
@@ -27,12 +27,13 @@ class FormParamConverter implements ParamConverterInterface
     private $handlers;
 
     /**
-     * @param ContainerInterface   $container
+     * @param ContainerInterface $container
+     * @param array              $handlers [$service_id => $class]
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, array $handlers = [])
     {
         $this->container = $container;
-        $this->handlers  = [];
+        $this->handlers  = $handlers;
     }
 
     /**
@@ -41,11 +42,15 @@ class FormParamConverter implements ParamConverterInterface
      */
     public function addFormClass($service_id, $class)
     {
+        @trigger_error(sprintf(
+            'Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use the constructor argument instead.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
         $this->handlers[$service_id] = $class;
     }
 
     /**
-     * @see \Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface::apply()
+     * {@inheritdoc}
      */
     public function apply(Request $request, ParamConverter $configuration)
     {
@@ -64,11 +69,11 @@ class FormParamConverter implements ParamConverterInterface
     }
 
     /**
-     * @see \Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface::supports()
+     * {@inheritdoc}
      */
     public function supports(ParamConverter $configuration)
     {
-        return in_array($configuration->getClass(), $this->handlers);
+        return in_array($configuration->getClass(), $this->handlers, true);
     }
 
     /**
@@ -86,12 +91,12 @@ class FormParamConverter implements ParamConverterInterface
         }
         if (count($service_ids) === 0) {
             throw new \InvalidArgumentException(
-                sprintf("No service_id found for parameter converter %s.", $configuration->getName())
+                sprintf('No service_id found for parameter converter %s.', $configuration->getName())
             );
         }
         if (count($service_ids) > 1) {
             throw new \InvalidArgumentException(
-                sprintf("More than one service_id found for parameter converter %s.", $configuration->getName())
+                sprintf('More than one service_id found for parameter converter %s.', $configuration->getName())
             );
         }
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -3,6 +3,7 @@ services:
         class: Hostnet\Bundle\FormHandlerBundle\ParamConverter\FormParamConverter
         arguments:
             - "@service_container"
+            - [] # inject from the compiler pass
         tags:
             - { name: request.param_converter, converter: form_information_converter }
 

--- a/test/ParamConverter/FormParamConverterTest.php
+++ b/test/ParamConverter/FormParamConverterTest.php
@@ -19,9 +19,7 @@ class FormParamConverterTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         if (!interface_exists('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')) {
-            $this->markTestSkipped(
-                'Sensio Extra bundle is not installed.'
-            );
+            $this->markTestSkipped('Sensio Extra bundle is not installed.');
             return;
         }
 
@@ -29,6 +27,10 @@ class FormParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->request   = new Request();
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use %s instead.
+     */
     public function testApplyFromServiceIdHandlerNotFound()
     {
         $configuration = new ParamConverter(['class' => 'Test\Henk', 'options' => ['service_id' => 'test.henk']]);
@@ -46,7 +48,11 @@ class FormParamConverterTest extends \PHPUnit_Framework_TestCase
         $converter->apply($this->request, $configuration);
     }
 
-    public function testApplyFromServiceId()
+    /**
+     * @group legacy
+     * @expectedDeprecation Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use %s instead.
+     */
+    public function testApplyFromServiceIdDeprecated()
     {
         $converter     = new FormParamConverter($this->container);
         $configuration = $this->buildParamConverter(
@@ -70,6 +76,36 @@ class FormParamConverterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($handler, $this->request->attributes->get('henk'));
     }
 
+    public function testApplyFromServiceId()
+    {
+        $converter = new FormParamConverter($this->container, [
+            'test.henk' => 'Hostnet\Bundle\FormHandlerBundle\ParamConverter\HandlerMock',
+        ]);
+
+        $configuration = $this->buildParamConverter(
+            'Hostnet\Bundle\FormHandlerBundle\ParamConverter\HandlerMock',
+            ['service_id' => 'test.henk'],
+            'henk'
+        );
+
+        $this->assertTrue($converter->supports($configuration));
+
+        $handler = new HandlerMock();
+
+        $this->container
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($handler));
+
+        $converter->apply($this->request, $configuration);
+
+        $this->assertEquals($handler, $this->request->attributes->get('henk'));
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use %s instead.
+     */
     public function testGetServiceIdForClassName()
     {
         $converter     = new FormParamConverter($this->container);
@@ -99,6 +135,9 @@ class FormParamConverterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use %s instead.
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testGetServiceIdForClassNameTooManyClassesForOneService()
@@ -120,7 +159,7 @@ class FormParamConverterTest extends \PHPUnit_Framework_TestCase
 
     private function buildParamConverter($class, array $options = [], $name = null)
     {
-        return  new ParamConverter([
+        return new ParamConverter([
             'class'   => $class,
             'options' => $options,
             'name'    => $name


### PR DESCRIPTION
This PR should provide a few small optimizations:
 - Only register FormHandlerInterface implementations in the parameter converter
 - Use an array in the constructor instead of a number of method calls 