### PR TITLE
Add alias for HandlerFactoryInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "hostnet/phpcs-tool":            "^4.1.0",
         "phpunit/phpunit":               "^4.7|^5.0",
         "sensio/framework-extra-bundle": "3.*",
+        "symfony/browser-kit":           "^3.0|^4.0",
         "symfony/finder":                "^2.7|^3.0|^4.0",
         "symfony/form":                  "^2.7|^3.0|^4.0",
         "symfony/framework-bundle":      "^2.7|^3.0|^4.0",

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -28,5 +28,5 @@ services:
     Hostnet\Bundle\FormHandlerBundle\Registry\LegacyHandlerRegistry: '@hostnet.form_handler.registry'
     Hostnet\Component\Form\FormProviderInterface: '@form_handler.provider.simple'
     Hostnet\Component\Form\Simple\SimpleFormProvider: '@form_handler.provider.simple'
-    Hostnet\Component\FormHandler\HandlerRegistryInterface: '@hostnet.form_handler.registry'
     Hostnet\Component\FormHandler\HandlerFactory: '@hostnet.form_handler.factory'
+    Hostnet\Component\FormHandler\HandlerFactoryInterface: '@hostnet.form_handler.factory'

--- a/test/Functional/ControllerTest.php
+++ b/test/Functional/ControllerTest.php
@@ -4,9 +4,8 @@
  */
 namespace Hostnet\Bundle\FormHandlerBundle\Functional;
 
-use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestController;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestKernel;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
@@ -14,14 +13,16 @@ use Symfony\Component\HttpKernel\Kernel;
  *
  * @author Gawain Lynch <gawain.lynch@gmail.com>
  */
-class ControllerTest extends KernelTestCase
+class ControllerTest extends WebTestCase
 {
+    private $client;
+
     /**
      * BC for current tests, new tests should get their own config.
      */
     protected function setUp()
     {
-        static::bootKernel(['config_file' => TestKernel::getLegacyConfigFilename()]);
+        $this->client = static::createClient(['config_file' => TestKernel::getLegacyConfigFilename()]);
     }
 
     protected static function createKernel(array $options = array())
@@ -29,7 +30,7 @@ class ControllerTest extends KernelTestCase
         return new TestKernel($options);
     }
 
-    public function test()
+    public function testActionInterfaceDependencyInjection()
     {
         if (Kernel::VERSION_ID < 30300) {
             self::markTestSkipped(sprintf('Symfony version %s not supported by test', Kernel::VERSION));
@@ -39,10 +40,8 @@ class ControllerTest extends KernelTestCase
             $this->markTestSkipped('Sensio Extra bundle is not installed.');
         }
 
-        $container = self::$kernel->getContainer();
-        $container->get(TestController::class);
+        $crawler = $this->client->request('GET', '/');
 
-        // We only care that the controller instantiates correctly
-        $this->addToAssertionCount(1);
+        self::assertSame('test', $crawler->text());
     }
 }

--- a/test/Functional/Fixtures/TestController.php
+++ b/test/Functional/Fixtures/TestController.php
@@ -5,10 +5,14 @@
 
 namespace Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures;
 
+use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\SimpleFormHandler;
 use Hostnet\Bundle\FormHandlerBundle\ParamConverter\FormParamConverter;
 use Hostnet\Bundle\FormHandlerBundle\Registry\LegacyHandlerRegistry;
 use Hostnet\Component\Form\Simple\SimpleFormProvider;
 use Hostnet\Component\FormHandler\HandlerFactory;
+use Hostnet\Component\FormHandler\HandlerFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Controller testing fixture.
@@ -36,5 +40,16 @@ class TestController
         $this->provider  = $provider;
         $this->registry  = $registry;
         $this->handler   = $handler;
+    }
+
+    public function action(Request $request, HandlerFactoryInterface $factory)
+    {
+        $handler  = $factory->create(SimpleFormHandler::class);
+        $response = $handler->handle($request);
+        if ($response instanceof Response) {
+            return $response;
+        }
+
+        return new Response('test');
     }
 }

--- a/test/Functional/Fixtures/config/routing.yml
+++ b/test/Functional/Fixtures/config/routing.yml
@@ -1,1 +1,4 @@
-
+app_action:
+    path: /
+    defaults:
+        _controller: 'Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestController::action'


### PR DESCRIPTION
Definitely a :koala: derp.

Controller test also now checks a route, hence the require-dev of `symfony/brower-kit`
