### PR TITLE
Remove 5.6 travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ php:
 
 matrix:
   include:
-    - php: 5.6
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
-      env: SYMFONY_VERSION="^2.8"
     - php: 7.0
       env: WITHOUT_EXTRA_BUNDLE=1
     - php: 7.1


### PR DESCRIPTION
5.6 Travis jobs are failing on composer installation with the following error message:

`symfony/browser-kit v4.1.6 requires php ^7.1.3 -> your PHP version (5.6.32) does not satisfy that requirement.` 

Proposed solution is to not run builds for PHP version 5.6 as our other dependencies have outgrown this PHP version.