### PR TITLE
Also allow browser-kit to have a lower symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "hostnet/phpcs-tool":            "^4.1.0",
         "phpunit/phpunit":               "^4.7|^5.0",
         "sensio/framework-extra-bundle": "3.*",
-        "symfony/browser-kit":           "^3.0|^4.0",
+        "symfony/browser-kit":           "^2.7|^3.0|^4.0",
         "symfony/finder":                "^2.7|^3.0|^4.0",
         "symfony/form":                  "^2.7|^3.0|^4.0",
         "symfony/framework-bundle":      "^2.7|^3.0|^4.0",


### PR DESCRIPTION
Probably fix Travis php 5.6 build errors by allowing `symfony/browser-kit` to have a lower version. 