### PR TITLE
Updates for Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ matrix:
       env: SYMFONY_VERSION="^4.0"
     - script: vendor/bin/phpcs -n
       env: PHPCS_BUILD=1
-    - php: 7.1
+    - php: 7.2
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="dev-master"
   allow_failures:
-    - php: 7.1
+    - php: 7.2
       env: COMPOSER_FLAGS="" SYMFONY_VERSION="dev-master"
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -16,22 +16,23 @@
     "require": {
         "php":                            "^5.6|^7.0",
         "hostnet/form-handler-component": "^1.4.0",
-        "symfony/expression-language":    "^2.7|^3.0|^4.0",
-        "symfony/http-foundation":        "^2.7|^3.0|^4.0"
+        "symfony/expression-language":    "^2.7|^3.0|^4.0|^5.0",
+        "symfony/http-foundation":        "^2.7|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "doctrine/annotations":          "^1.0",
         "hostnet/phpcs-tool":            "^4.1.0",
-        "phpunit/phpunit":               "^4.7|^5.0",
-        "sensio/framework-extra-bundle": "3.*",
-        "symfony/browser-kit":           "^2.7|^3.0|^4.0",
-        "symfony/finder":                "^2.7|^3.0|^4.0",
-        "symfony/form":                  "^2.7|^3.0|^4.0",
-        "symfony/framework-bundle":      "^2.7|^3.0|^4.0",
-        "symfony/http-kernel":           "^2.7|^3.0|^4.0",
-        "symfony/phpunit-bridge":        "^2.8|^3.0|^4.0",
-        "symfony/translation":           "^2.7|^3.0|^4.0",
-        "symfony/validator":             "^2.7|^3.0|^4.0"
+        "phpunit/phpunit":               "^4.8.36|^5.7|^7.5",
+        "sensio/framework-extra-bundle": "3.*|^5.0",
+        "symfony/browser-kit":           "^2.7|^3.0|^4.0|^5.0",
+        "symfony/finder":                "^2.7|^3.0|^4.0|^5.0",
+        "symfony/form":                  "^2.7|^3.0|^4.0|^5.0",
+        "symfony/framework-bundle":      "^2.7|^3.0|^4.0|^5.0",
+        "symfony/http-kernel":           "^2.7|^3.0|^4.0|^5.0",
+        "symfony/phpunit-bridge":        "^2.8|^3.0|^4.0|^5.0",
+        "symfony/translation":           "^2.7|^3.0|^4.0|^5.0",
+        "symfony/validator":             "^2.7|^3.0|^4.0|^5.0",
+        "symfony/yaml":                  "^2.7|^3.0|^4.0|^5.0"
     },
     "suggest": {
         "sensio/framework-extra-bundle": "To utilize form param converter."

--- a/test/DependencyInjection/FormHandlerRegistryCompilerPassTest.php
+++ b/test/DependencyInjection/FormHandlerRegistryCompilerPassTest.php
@@ -5,6 +5,7 @@
 namespace Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler;
 
 use Hostnet\Bundle\FormHandlerBundle\ParamConverter\FormParamConverter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -12,7 +13,7 @@ use Symfony\Component\DependencyInjection\Definition;
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
  * @covers \Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormHandlerRegistryCompilerPass
  */
-class FormHandlerRegistryCompilerPassTest extends \PHPUnit_Framework_TestCase
+class FormHandlerRegistryCompilerPassTest extends TestCase
 {
     protected function setUp()
     {

--- a/test/FormHandlerBundleTest.php
+++ b/test/FormHandlerBundleTest.php
@@ -4,13 +4,14 @@
  */
 namespace Hostnet\Bundle\FormHandlerBundle;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Piotr Rzeczkowski <piotr@rzeka.net>
- * @coversDefaultClass Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle
+ * @coversDefaultClass \Hostnet\Bundle\FormHandlerBundle\FormHandlerBundle
  */
-class FormHandlerBundleTest extends \PHPUnit_Framework_TestCase
+class FormHandlerBundleTest extends TestCase
 {
     public function testIsInstanceOfFormHandlerBundle()
     {

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -24,6 +24,11 @@ final class TestKernel extends Kernel
 
     public static function getLegacyConfigFilename()
     {
+        if (Kernel::VERSION_ID >= 40200) {
+            return 'config_42.yml';
+        }
+
+
         if (Kernel::VERSION_ID >= 30300) {
             return 'config_33.yml';
         }
@@ -33,6 +38,11 @@ final class TestKernel extends Kernel
         }
 
         return 'config_27.yml';
+    }
+
+    public function getProjectDir()
+    {
+        return __DIR__;
     }
 
     /**

--- a/test/Functional/Fixtures/config/autoconfigure.yml
+++ b/test/Functional/Fixtures/config/autoconfigure.yml
@@ -14,7 +14,7 @@ framework:
     test: true
     secret: test
     router:
-        resource: '%kernel.root_dir%/config/routing.yml'
+        resource: '%kernel.project_dir%/config/routing.yml'
     form: true
     validation:
         enable_annotations: true

--- a/test/Functional/Fixtures/config/config_42.yml
+++ b/test/Functional/Fixtures/config/config_42.yml
@@ -1,0 +1,48 @@
+services:
+    _defaults:
+        autoconfigure: true
+        autowire: true
+
+    Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\:
+        resource: '../HandlerType'
+
+    Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\:
+        resource: '../Legacy'
+
+    Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\SimpleNotTaggedFormHandler:
+        autoconfigure: false
+
+    app.handler.type.full_form:
+        alias: 'Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\FullFormHandler'
+        public: true
+
+    app.handler.type.simple_form:
+        alias: 'Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\SimpleFormHandler'
+        public: true
+
+    app.handler.type.simple_form_not_tagged: '@Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\HandlerType\SimpleNotTaggedFormHandler'
+    app.handler.legacy.normal:
+        alias: 'Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyFormHandler'
+        public: true
+
+    app.handler.legacy.variable:
+        alias: 'Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyFormVariableOptionsHandler'
+        public: true
+
+    app.handler.legacy.named:
+        alias: 'Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyNamedFormHandler'
+        public: true
+
+    Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestController:
+        tags: ['controller.service_arguments']
+
+framework:
+    test: true
+    secret: test
+    router:
+        resource: '%kernel.project_dir%/config/routing.yml'
+    form: true
+    validation:
+        enable_annotations: true
+    translator:
+        fallback: en

--- a/test/HostnetFormHandlerBundleTest.php
+++ b/test/HostnetFormHandlerBundleTest.php
@@ -7,13 +7,14 @@ namespace Hostnet\Bundle\FormHandlerBundle;
 use Hostnet\Bundle\FormHandlerBundle\DependencyInjection\Compiler\FormHandlerRegistryCompilerPass;
 use Hostnet\Component\Form\FormHandlerInterface;
 use Hostnet\Component\FormHandler\HandlerTypeInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
- * @coversDefaultClass Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle
+ * @coversDefaultClass \Hostnet\Bundle\FormHandlerBundle\HostnetFormHandlerBundle
  */
-class HostnetFormHandlerBundleTest extends \PHPUnit_Framework_TestCase
+class HostnetFormHandlerBundleTest extends TestCase
 {
     public function testBuild()
     {

--- a/test/ParamConverter/FormParamConverterTest.php
+++ b/test/ParamConverter/FormParamConverterTest.php
@@ -4,6 +4,7 @@
  */
 namespace Hostnet\Bundle\FormHandlerBundle\ParamConverter;
 
+use PHPUnit\Framework\TestCase;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -11,7 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
  * @covers \Hostnet\Bundle\FormHandlerBundle\ParamConverter\FormParamConverter
  */
-class FormParamConverterTest extends \PHPUnit_Framework_TestCase
+class FormParamConverterTest extends TestCase
 {
     private $container;
     private $request;


### PR DESCRIPTION
Companion PR for with https://github.com/hostnet/form-handler-component/pull/29

- Update composer.json constraints for Symfony 5
- Include symfony/yaml as a specific require-dev
- [Travis] Use PHP 7.2 for Symfony dev-master
- Handle upstream deprecations
  - Migrate kernel.root_dir to kernel.project_dir
  - TestKernel override getProjectDir()
- Bump Minimum PHPUnit version to ^4.8
- Update PHPUnit & namespaces