### PR TITLE
update phpunit to 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,9 @@
 {
-    "name":        "hostnet/form-handler-bundle",
-    "type":        "symfony-bundle",
-    "description": "Hostnet form handler to provide an easier way of handling forms in actions",
-    "license":     "MIT",
-    "authors": [
-        {
-            "name":  "Iltar van der Berg",
-            "email": "ivanderberg@hostnet.nl"
-        },
-        {
-            "name":  "Yannick de Lange",
-            "email": "ydelange@hostnet.nl"
-        }
-    ],
+    "name":              "hostnet/form-handler-bundle",
+    "type":              "symfony-bundle",
+    "description":       "Hostnet form handler to provide an easier way of handling forms in actions",
+    "license":           "MIT",
+    "minimum-stability": "stable",
     "require": {
         "php":                            ">=7.3",
         "hostnet/form-handler-component": "^1.4.0",
@@ -22,7 +13,7 @@
     "require-dev": {
         "doctrine/annotations":          "^1.0",
         "hostnet/phpcs-tool":            "^8.3",
-        "phpunit/phpunit":               "^5.7|^7.5",
+        "phpunit/phpunit":               "^9.5.5",
         "sensio/framework-extra-bundle": "3.*|^5.0",
         "symfony/browser-kit":           "^4.0|^5.0",
         "symfony/finder":                "^4.0|^5.0",
@@ -50,8 +41,6 @@
             "test/Functional/Fixtures/TestKernel.php"
         ]
     },
-    "minimum-stability" : "dev",
-    "prefer-stable"     : true,
     "archive": {
         "exclude": [
             "/test"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.0/phpunit.xsd"
-    colors="true" bootstrap="vendor/autoload.php">
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
-
-    <testsuites>
-        <testsuite name="hostnet/form-handler-bundle test suite">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true" bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
+  <testsuites>
+    <testsuite name="hostnet/form-handler-bundle test suite">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/DependencyInjection/FormHandlerRegistryCompilerPassTest.php
+++ b/test/DependencyInjection/FormHandlerRegistryCompilerPassTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class FormHandlerRegistryCompilerPassTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!interface_exists('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')) {
             $this->markTestSkipped(
@@ -28,7 +28,7 @@ class FormHandlerRegistryCompilerPassTest extends TestCase
     /**
      * @dataProvider processDataProvider
      */
-    public function testProcess($service_name, $tagged_services)
+    public function testProcess($service_name, $tagged_services): void
     {
         $container = new ContainerBuilder();
         $container->setDefinition($service_name, new Definition());
@@ -47,7 +47,7 @@ class FormHandlerRegistryCompilerPassTest extends TestCase
         );
     }
 
-    public function processDataProvider()
+    public function processDataProvider(): iterable
     {
         return [
             ['form_handler.param_converter', []],

--- a/test/FormHandlerBundleTest.php
+++ b/test/FormHandlerBundleTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class FormHandlerBundleTest extends TestCase
 {
-    public function testIsInstanceOfFormHandlerBundle()
+    public function testIsInstanceOfFormHandlerBundle(): void
     {
         $bundle = new FormHandlerBundle();
 
@@ -26,7 +26,7 @@ class FormHandlerBundleTest extends TestCase
      * @group legacy
      * @expectedDeprecation The %s is deprecated. Use %s instead.
      */
-    public function testIsDeprecated()
+    public function testIsDeprecated(): void
     {
         $container = new ContainerBuilder();
         $bundle    = new FormHandlerBundle();

--- a/test/Functional/AutoconfigureTest.php
+++ b/test/Functional/AutoconfigureTest.php
@@ -14,10 +14,11 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class AutoconfigureTest extends KernelTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (Kernel::VERSION_ID < 30300) {
             self::markTestSkipped(sprintf('Symfony version %s not supported by test', Kernel::VERSION));
@@ -25,12 +26,12 @@ class AutoconfigureTest extends KernelTestCase
         static::bootKernel(['config_file' => 'autoconfigure.yml']);
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         return new TestKernel($options);
     }
 
-    public function testHandlerType()
+    public function testHandlerType(): void
     {
         $container       = self::$kernel->getContainer();
         $handler_factory = $container->get('hostnet.form_handler.factory');
@@ -49,7 +50,7 @@ class AutoconfigureTest extends KernelTestCase
      * @group legacy
      * @expectedDeprecation Using %s is deprecated, use Hostnet\Component\FormHandler\HandlerTypeInterface instead.
      */
-    public function testFormHandler()
+    public function testFormHandler(): void
     {
         $container       = self::$kernel->getContainer();
         $handler_factory = $container->get('hostnet.form_handler.factory');

--- a/test/Functional/ControllerTest.php
+++ b/test/Functional/ControllerTest.php
@@ -9,6 +9,7 @@ namespace Hostnet\Bundle\FormHandlerBundle\Functional;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Controller test.
@@ -20,17 +21,17 @@ class ControllerTest extends WebTestCase
     /**
      * BC for current tests, new tests should get their own config.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->test_client = static::createClient(['config_file' => TestKernel::getLegacyConfigFilename()]);
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         return new TestKernel($options);
     }
 
-    public function testActionInterfaceDependencyInjection()
+    public function testActionInterfaceDependencyInjection(): void
     {
         if (Kernel::VERSION_ID < 30300) {
             self::markTestSkipped(sprintf('Symfony version %s not supported by test', Kernel::VERSION));

--- a/test/Functional/HandlerTest.php
+++ b/test/Functional/HandlerTest.php
@@ -14,23 +14,24 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class HandlerTest extends KernelTestCase
 {
     /**
      * BC for current tests, new tests should get their own config.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel(['config_file' => TestKernel::getLegacyConfigFilename()]);
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         return new TestKernel($options);
     }
 
-    public function testValid()
+    public function testValid(): void
     {
         if (Kernel::VERSION_ID < 20800) {
             self::markTestSkipped(sprintf('Symfony version %s not supported by test', Kernel::VERSION));
@@ -49,7 +50,7 @@ class HandlerTest extends KernelTestCase
         self::assertEquals('http://success.nl/', $response->getTargetUrl());
     }
 
-    public function testInvalid()
+    public function testInvalid(): void
     {
         if (Kernel::VERSION_ID < 20800) {
             self::markTestSkipped(sprintf('Symfony version %s not supported by test', Kernel::VERSION));
@@ -71,7 +72,7 @@ class HandlerTest extends KernelTestCase
     /**
      * @group legacy
      */
-    public function testValid27()
+    public function testValid27(): void
     {
         if (Kernel::VERSION_ID >= 30000) {
             self::markTestSkipped(sprintf('Symfony version %s not supported by test', Kernel::VERSION));
@@ -93,7 +94,7 @@ class HandlerTest extends KernelTestCase
     /**
      * @group legacy
      */
-    public function testInvalid27()
+    public function testInvalid27(): void
     {
         if (Kernel::VERSION_ID >= 30000) {
             self::markTestSkipped(sprintf('Symfony version %s not supported by test', Kernel::VERSION));

--- a/test/Functional/RegistryTest.php
+++ b/test/Functional/RegistryTest.php
@@ -13,26 +13,27 @@ use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyFormHandle
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyFormVariableOptionsHandler;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\Legacy\LegacyNamedFormHandler;
 use Hostnet\Bundle\FormHandlerBundle\Functional\Fixtures\TestKernel;
+use Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException;
 use Hostnet\Component\FormHandler\HandlerTypeAdapter;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class RegistryTest extends KernelTestCase
 {
     /**
      * BC for current tests, new tests should get their own config.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel(['config_file' => TestKernel::getLegacyConfigFilename()]);
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         return new TestKernel($options);
     }
 
-    public function test()
+    public function test(): void
     {
         $container = self::$kernel->getContainer();
         $registry  = $container->get('hostnet.form_handler.registry');
@@ -61,24 +62,22 @@ class RegistryTest extends KernelTestCase
         );
     }
 
-    /**
-     * @expectedException \Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException
-     */
-    public function testMissing()
+    public function testMissing(): void
     {
         $container = self::$kernel->getContainer();
         $registry  = $container->get('hostnet.form_handler.registry');
+
+        $this->expectException(InvalidHandlerTypeException::class);
 
         $registry->getType(\stdClass::class);
     }
 
-    /**
-     * @expectedException \Hostnet\Component\FormHandler\Exception\InvalidHandlerTypeException
-     */
-    public function testNotTagged()
+    public function testNotTagged(): void
     {
         $container = self::$kernel->getContainer();
         $registry  = $container->get('hostnet.form_handler.registry');
+
+        $this->expectException(InvalidHandlerTypeException::class);
 
         $registry->getType(SimpleNotTaggedFormHandler::class);
     }

--- a/test/HostnetFormHandlerBundleTest.php
+++ b/test/HostnetFormHandlerBundleTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class HostnetFormHandlerBundleTest extends TestCase
 {
-    public function testBuild()
+    public function testBuild(): void
     {
         $container = new ContainerBuilder();
 

--- a/test/ParamConverter/FormParamConverterTest.php
+++ b/test/ParamConverter/FormParamConverterTest.php
@@ -18,7 +18,7 @@ class FormParamConverterTest extends TestCase
     private $container;
     private $request;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!interface_exists('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')) {
             $this->markTestSkipped('Sensio Extra bundle is not installed.');
@@ -33,7 +33,7 @@ class FormParamConverterTest extends TestCase
      * @group legacy
      * @expectedDeprecation Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use %s instead.
      */
-    public function testApplyFromServiceIdHandlerNotFound()
+    public function testApplyFromServiceIdHandlerNotFound(): void
     {
         $configuration = new ParamConverter(['class' => 'Test\Henk', 'options' => ['service_id' => 'test.henk']]);
         $converter     = new FormParamConverter($this->container);
@@ -54,7 +54,7 @@ class FormParamConverterTest extends TestCase
      * @group legacy
      * @expectedDeprecation Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use %s instead.
      */
-    public function testApplyFromServiceIdDeprecated()
+    public function testApplyFromServiceIdDeprecated(): void
     {
         $converter     = new FormParamConverter($this->container);
         $configuration = $this->buildParamConverter(
@@ -78,7 +78,7 @@ class FormParamConverterTest extends TestCase
         $this->assertEquals($handler, $this->request->attributes->get('henk'));
     }
 
-    public function testApplyFromServiceId()
+    public function testApplyFromServiceId(): void
     {
         $converter = new FormParamConverter($this->container, [
             'test.henk' => 'Hostnet\Bundle\FormHandlerBundle\ParamConverter\HandlerMock',
@@ -108,7 +108,7 @@ class FormParamConverterTest extends TestCase
      * @group legacy
      * @expectedDeprecation Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use %s instead.
      */
-    public function testGetServiceIdForClassName()
+    public function testGetServiceIdForClassName(): void
     {
         $converter     = new FormParamConverter($this->container);
         $configuration = $this->buildParamConverter(
@@ -121,10 +121,7 @@ class FormParamConverterTest extends TestCase
         $converter->apply($this->request, $configuration);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testGetServiceIdForClassNameNoMatch()
+    public function testGetServiceIdForClassNameNoMatch(): void
     {
         $converter     = new FormParamConverter($this->container);
         $configuration = $this->buildParamConverter(
@@ -133,16 +130,16 @@ class FormParamConverterTest extends TestCase
             'henk'
         );
 
+        $this->expectException(\InvalidArgumentException::class);
+
         $converter->apply($this->request, $configuration);
     }
 
     /**
      * @group legacy
      * @expectedDeprecation Calling %s is deprecated as of 1.6 and will be removed in 2.0. Use %s instead.
-     *
-     * @expectedException \InvalidArgumentException
      */
-    public function testGetServiceIdForClassNameTooManyClassesForOneService()
+    public function testGetServiceIdForClassNameTooManyClassesForOneService(): void
     {
         $converter     = new FormParamConverter($this->container);
         $configuration = $this->buildParamConverter(
@@ -156,10 +153,12 @@ class FormParamConverterTest extends TestCase
             $converter->addFormClass($id, 'Hostnet\Bundle\FormHandlerBundle\ParamConverter\HandlerMock');
         }
 
+        $this->expectException(\InvalidArgumentException::class);
+
         $converter->apply($this->request, $configuration);
     }
 
-    private function buildParamConverter($class, array $options = [], $name = null)
+    private function buildParamConverter($class, array $options = [], $name = null): ParamConverter
     {
         return new ParamConverter([
             'class'   => $class,


### PR DESCRIPTION
Changed minimum stability to stable to prevent installing unstable symfony 5.4-dev packages.